### PR TITLE
clk: hi6220: fix compile error on arm32

### DIFF
--- a/drivers/clk/hisilicon/Makefile
+++ b/drivers/clk/hisilicon/Makefile
@@ -2,9 +2,9 @@
 # Hisilicon Clock specific Makefile
 #
 
-obj-y	+= clk.o clkgate-separated.o
+obj-y	+= clk.o clkgate-separated.o clkdivider-hi6220.o
 
 obj-$(CONFIG_ARCH_HI3xxx)	+= clk-hi3620.o
 obj-$(CONFIG_ARCH_HIP04)	+= clk-hip04.o
 obj-$(CONFIG_ARCH_HIX5HD2)	+= clk-hix5hd2.o
-obj-$(CONFIG_COMMON_CLK_HI6220)	+= clkdivider-hi6220.o clk-hi6220.o
+obj-$(CONFIG_COMMON_CLK_HI6220)	+= clk-hi6220.o


### PR DESCRIPTION
Fix the following compile error when choose arm32 platform:

drivers/built-in.o: In function i6220_clk_register_divider':
:(.init.text+0x1a84c): undefined reference to i6220_register_clkdiv'
Makefile:925: recipe for target 'vmlinux' failed
make: **\* [vmlinux] Error 1

Signed-off-by: Bintian Wang bintian.wang@huawei.com
Reported-by: tyler.baker@linaro.org
