### PR TITLE
wlcore/wl18xx: set default .sta_sleep_auth to WL1271_PSM_CAM

### DIFF
--- a/drivers/net/wireless/ti/wl18xx/main.c
+++ b/drivers/net/wireless/ti/wl18xx/main.c
@@ -377,7 +377,7 @@ static struct wlcore_conf wl18xx_conf = {
 		.forced_ps                   = false,
 		.keep_alive_interval         = 55000,
 		.max_listen_interval         = 20,
-		.sta_sleep_auth              = WL1271_PSM_ILLEGAL,
+		.sta_sleep_auth              = WL1271_PSM_CAM,
 		.suspend_rx_ba_activity      = 0,
 	},
 	.itrim = {


### PR DESCRIPTION
Workaround to ELP wakeup failure issue on Hikey. Setting .sta_sleep_auth to
WL1271_PSM_CAM can disable ELP mode.

Note: values in wl18xx-conf.bin have higher priority; and once set, it can
overwrite the setting here.

Signed-off-by: Guodong Xu guodong.xu@linaro.org
Signed-off-by: Xinwei Kong kong.kongxinwei@hisilicon.com
