### PR TITLE
	perf_hip05: Enable Hisilicon Perf support default

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -599,7 +599,7 @@ config HW_PERF_EVENTS
 config HISI_PERFCTR
 	bool "Enable hardware event counter support for HiSilicon SoC"
 	depends on HW_PERF_EVENTS
-	default n
+	default y
 	help
 	 Enable hardware event counter support for Hisilicon SoC LLC,
 	 MN and DDR events.


### PR DESCRIPTION
```
1. Enable Hisilicon Perf support default.
```

Signed-off-by: Anurup M anurup.m@huawei.com
