### PR TITLE
d03: net: slove mac conflict

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hip06-d03.dts
+++ b/arch/arm64/boot/dts/hisilicon/hip06-d03.dts
@@ -12,7 +12,6 @@
 /dts-v1/;
 
 #include "hip06.dtsi"
-#include "hip06_hns.dtsi"
 / {
 	model = "Hisilicon Hip06 D03 Development Board";
 	compatible = "hisilicon,hip06-d03";

--- a/arch/arm64/boot/dts/hisilicon/hip06.dtsi
+++ b/arch/arm64/boot/dts/hisilicon/hip06.dtsi
@@ -501,6 +501,7 @@
 		interrupts = <1 7 4>;
 	};
 
+	/include/ "hip06_hns.dtsi"
 	soc {
 		compatible = "simple-bus";
 		#address-cells = <2>;

--- a/arch/arm64/boot/dts/hisilicon/hip06_hns.dtsi
+++ b/arch/arm64/boot/dts/hisilicon/hip06_hns.dtsi
@@ -1,4 +1,3 @@
-/ {
 	soc0: soc@000000000 {
 		#address-cells = <2>;
 		#size-cells = <2>;
@@ -270,7 +269,7 @@
 			dma-coherent;
 
 		};
-		eth0: ethernet@6{
+		eth0: ethernet@4{
 			compatible = "hisilicon,hns-nic-v2";
 			ae-name = "dsaf0";
 			port-id = <6>;
@@ -278,7 +277,7 @@
 			local-mac-address = [00 00 00 01 ff 00];
 			dma-coherent; 
 		};
-		eth1: ethernet7{
+		eth1: ethernet5{
 			compatible = "hisilicon,hns-nic-v2";
 			ae-name = "dsaf0";
 			port-id = <7>;
@@ -286,7 +285,7 @@
 			status = "disabled";
 			dma-coherent;
 		};
-		eth2: ethernet@2{
+		eth2: ethernet@0{
 			compatible = "hisilicon,hns-nic-v2";
 			ae-name = "dsaf0";
 			port-id = <2>;
@@ -294,7 +293,7 @@
 			status = "disabled";
 			dma-coherent;
 		};
-		eth3: ethernet@3{
+		eth3: ethernet@1{
 			compatible = "hisilicon,hns-nic-v2";
 			ae-name = "dsaf0";
 			port-id = <3>;
@@ -302,7 +301,7 @@
 			status = "disabled";
 			dma-coherent;
 		};
-		eth4: ethernet@4{
+		eth4: ethernet@2{
 			compatible = "hisilicon,hns-nic-v2";
 			ae-name = "dsaf0";
 			port-id = <4>;
@@ -310,7 +309,7 @@
 			status = "disabled";
 			dma-coherent;
 		};
-		eth5: ethernet@5{
+		eth5: ethernet@3{
 			compatible = "hisilicon,hns-nic-v2";
 			ae-name = "dsaf0";
 			port-id = <5>;
@@ -318,7 +317,7 @@
 			status = "disabled";
 			dma-coherent;
 		};
-		eth6: ethernet@0{
+		eth6: ethernet@6{
 			compatible = "hisilicon,hns-nic-v2";
 			ae-name = "dsaf0";
 			port-id = <0>;
@@ -326,7 +325,7 @@
 			status = "disabled";
 			dma-coherent;
 		};
-		eth7: ethernet@1{
+		eth7: ethernet@7{
 			compatible = "hisilicon,hns-nic-v2";
 			ae-name = "dsaf0";
 			port-id = <1>;
@@ -336,4 +335,3 @@
 		};
 
 	}; /*soc 0*/
-};


### PR DESCRIPTION
do not use eeprom mac address and produce this dtb mac address
by fixing this dts to slove it

Signed-off-by: Xinwei Kong kong.kongxinwei@hisilicon.com
