### PR TITLE
scsi: ignore errors from scsi_dh_add_device()

### DIFF
--- a/drivers/scsi/scsi_dh.c
+++ b/drivers/scsi/scsi_dh.c
@@ -76,10 +76,10 @@ static const char *
 scsi_dh_find_driver(struct scsi_device *sdev)
 {
 	const struct scsi_dh_blist *b;
-#if 0
+
 	if (scsi_device_tpgs(sdev))
 		return "alua";
-#endif
+
 	for (b = scsi_dh_blist; b->vendor; b++) {
 		if (!strncmp(sdev->vendor, b->vendor, strlen(b->vendor)) &&
 		    !strncmp(sdev->model, b->model, strlen(b->model))) {

--- a/drivers/scsi/scsi_sysfs.c
+++ b/drivers/scsi/scsi_sysfs.c
@@ -1058,11 +1058,9 @@ int scsi_sysfs_add_sdev(struct scsi_device *sdev)
 	}
 
 	error = scsi_dh_add_device(sdev);
-	if (error) {
+	if (error) 
 		sdev_printk(KERN_INFO, sdev,
 				"failed to add device handler: %d\n", error);
-		return error;
-	}
 
 	device_enable_async_suspend(&sdev->sdev_dev);
 	error = device_add(&sdev->sdev_dev);


### PR DESCRIPTION
device handler initialisation might fail due to a number of
reasons. But as device_handlers are optional this shouldn't
cause us to disable the device entirely. So just ignore errors
from scsi_dh_add_device().

Reviewed-by: Johannes Thumshirn jthumshirn@suse.com
Reviewed-by: Christoph Hellwig hch@lst.de
Signed-off-by: Hannes Reinecke hare@suse.de
Signed-off-by: Martin K. Petersen martin.petersen@oracle.com
Signed-off-by: Xinwei Kong kong.kongxinwei@hisilicon.com
