### PR TITLE
kvm: D0x: ACPI: Update oem_table_id

### DIFF
--- a/drivers/irqchip/irq-gic-v3.c
+++ b/drivers/irqchip/irq-gic-v3.c
@@ -1318,8 +1318,8 @@ static void __init acpi_madt_oem_check(char *oem_id, char *oem_table_id)
      * because GIC on D02 and D03 don't support that
      */
     if (!strncmp(oem_id, "HISI", 4)
-        && (!strncmp(oem_table_id, "HISI-D02", 8)
-        || !strncmp(oem_table_id, "HISI-D03", 8)))
+        && (!strncmp(oem_table_id, "HISI0660", 8)
+        || !strncmp(oem_table_id, "HISI1610", 8)))
         gic_v3_kvm_info.timer_irqmap_disabled = true;
 }
 


### PR DESCRIPTION
For D02 oem_table_id is update to "HISI0660".
And D03 updated to "HISI1610".

Signed-off-by: Xinliang Liu xinliang.liu@linaro.org
