### PR TITLE
libsas:Fix the sysfs device tree call trace when unplug disk or sas w…

### DIFF
--- a/drivers/scsi/libsas/sas_discover.c
+++ b/drivers/scsi/libsas/sas_discover.c
@@ -362,11 +362,17 @@ static void sas_destruct_devices(struct work_struct *work)
 	clear_bit(DISCE_DESTRUCT, &port->disc.pending);
 
 	list_for_each_entry_safe(dev, n, &port->destroy_list, disco_list_node) {
+		struct sas_port *sas_port =
+			dev_to_sas_port(dev->rphy->dev.parent);
+
 		list_del_init(&dev->disco_list_node);
 
 		sas_remove_children(&dev->rphy->dev);
 		sas_rphy_delete(dev->rphy);
 		sas_unregister_common_dev(port, dev);
+
+		if (sas_port->num_phys == 0)
+			sas_port_delete(sas_port);
 	}
 }
 

--- a/drivers/scsi/libsas/sas_expander.c
+++ b/drivers/scsi/libsas/sas_expander.c
@@ -1902,8 +1902,6 @@ static void sas_unregister_devs_sas_addr(struct domain_device *parent,
 	if (phy->port) {
 		sas_port_delete_phy(phy->port, phy->phy);
 		sas_device_set_phy(found, phy->port);
-		if (phy->port->num_phys == 0)
-			sas_port_delete(phy->port);
 		phy->port = NULL;
 	}
 }

--- a/drivers/scsi/libsas/sas_port.c
+++ b/drivers/scsi/libsas/sas_port.c
@@ -218,8 +218,8 @@ void sas_deform_port(struct asd_sas_phy *phy, int gone)
 		dev->pathways--;
 
 	if (port->num_phys == 1) {
+		sas_port_delete_phy(port->port, phy->phy);
 		sas_unregister_domain_devices(port, gone);
-		sas_port_delete(port->port);
 		port->port = NULL;
 	} else {
 		sas_port_delete_phy(port->port, phy->phy);


### PR DESCRIPTION
…ire.

This patch fix the sysfs device tree call trace, see it belows,
when user unplugs the disk or sas wire, the disk may run commands
or not.It just delays the deletion of the port after the disk or
expander has been deleted, as the port device node is the parent
of the disk or expander device node in linux device tree.

The sysfs device tree call trace as follows:
------------[ cut here ]------------
WARNING: CPU: 11 PID: 168 at fs/sysfs/group.c:224
            sysfs_remove_group+0x9c/0xa0()
sysfs group ffff800000a49ae0 not found for kobject 'end_device-2:0:11'
Modules linked in:

CPU: 11 PID: 168 Comm: kworker/u64:1 Tainted: G        W       4.1.23+ #10
Hardware name: Hisilicon Hi1610 32core Evaluation Board (DT)
Workqueue: scsi_wq_2 sas_destruct_devices
Call trace:
[<ffff8000000896d0>] dump_backtrace+0x0/0x120
[<ffff800000089804>] show_stack+0x14/0x1c
[<ffff80000073b988>] dump_stack+0x90/0xb0
[<ffff8000000a2828>] warn_slowpath_common+0x98/0xd0
[<ffff8000000a28b0>] warn_slowpath_fmt+0x50/0x58
[<ffff8000001fef7c>] sysfs_remove_group+0x9c/0xa0
[<ffff8000003d61d4>] dpm_sysfs_remove+0x58/0x68
[<ffff8000003cb14c>] device_del+0x40/0x208
[<ffff800000413534>] sas_rphy_remove+0x54/0x80
[<ffff800000413574>] sas_rphy_delete+0x14/0x28
[<ffff800000417780>] sas_destruct_devices+0x64/0x98
[<ffff8000000b84e0>] process_one_work+0x14c/0x350
[<ffff8000000b881c>] worker_thread+0x138/0x49c
[<ffff8000000bdfe8>] kthread+0xdc/0xf0
---[ end trace dc675afc987f0b24 ]---

Signed-off-by: Yousong He heyousong@huawei.com
Signed-off-by: Qilin Chen chenqilin2@huawei.com
Signed-off-by: Jian Luo luojian5@huawei.com
Signed-off-by: Misheng Xue xuemisheng@huawei.com
Signed-off-by: Dengyun He hedengyun@huawei.com
Signed-off-by: Ding Tianhong dingtianhong@huawei.com
