### PR TITLE
arm64: Call numa_store_cpu_info() earlier.

### DIFF
--- a/arch/arm64/kernel/smp.c
+++ b/arch/arm64/kernel/smp.c
@@ -201,12 +201,6 @@ int __cpu_up(unsigned int cpu, struct task_struct *idle)
 	return ret;
 }
 
-static void smp_store_cpu_info(unsigned int cpuid)
-{
-	store_cpu_topology(cpuid);
-	numa_store_cpu_info(cpuid);
-}
-
 /*
  * This is the secondary CPU boot entry.  We're using this CPUs
  * idle thread stack, but a set of temporary page tables.
@@ -253,8 +247,7 @@ asmlinkage void secondary_start_kernel(void)
 	 * Enable GIC and timers.
 	 */
 	notify_cpu_starting(cpu);
-
-	smp_store_cpu_info(cpu);
+	store_cpu_topology(cpu);
 
 	/*
 	 * OK, now it's safe to let the boot CPU continue.  Wait for
@@ -690,11 +683,13 @@ void __init smp_prepare_cpus(unsigned int max_cpus)
 {
 	int err;
 	unsigned int cpu;
+	unsigned int this_cpu;
 
 	init_cpu_topology();
 
-	smp_store_cpu_info(smp_processor_id());
-
+	this_cpu = smp_processor_id();
+	store_cpu_topology(this_cpu);
+	numa_store_cpu_info(this_cpu);
 	/*
 	 * Initialise the present map (which describes the set of CPUs
 	 * actually populated at the present time) and release the
@@ -713,6 +708,7 @@ void __init smp_prepare_cpus(unsigned int max_cpus)
 			continue;
 
 		set_cpu_present(cpu, true);
+		numa_store_cpu_info(cpu);
 	}
 }
 


### PR DESCRIPTION
The wq_numa_init() function makes a private CPU to node map by calling
cpu_to_node() early in the boot process, before the non-boot CPUs are
brought online.  Since the default implementation of cpu_to_node()
returns zero for CPUs that have never been brought online, the
workqueue system's view is that _all_ CPUs are on node zero.

When the unbound workqueue for a non-zero node is created, the
tsk_cpus_allowed() for the worker threads is the empty set because
there are, in the view of the workqueue system, no CPUs on non-zero
nodes.  The code in try_to_wake_up() using this empty cpumask ends up
using the cpumask empty set value of NR_CPUS as an index into the
per-CPU area pointer array, and gets garbage as it is one past the end
of the array.  This results in:

 [    2.523156] fa60: 0000000000000000 0000000000000000
 [    2.528089] [<fffffc00080e7468>] try_to_wake_up+0x194/0x34c
 [    2.533723] [<fffffc00080e7648>] wake_up_process+0x28/0x34
 [    2.539275] [<fffffc00080d3764>] create_worker+0x110/0x19c
 [    2.544824] [<fffffc00080d69dc>] alloc_unbound_pwq+0x3cc/0x4b0
 [    2.550724] [<fffffc00080d6bcc>] wq_update_unbound_numa+0x10c/0x1e4
 [    2.557066] [<fffffc00080d7d78>] workqueue_online_cpu+0x220/0x28c
 [    2.563234] [<fffffc00080bd288>] cpuhp_invoke_callback+0x6c/0x168
 [    2.569398] [<fffffc00080bdf74>] cpuhp_up_callbacks+0x44/0xe4
 [    2.575210] [<fffffc00080be194>] cpuhp_thread_fun+0x13c/0x148
 [    2.581027] [<fffffc00080dfbac>] smpboot_thread_fn+0x19c/0x1a8
 [    2.586929] [<fffffc00080dbd64>] kthread+0xdc/0xf0
 [    2.591776] [<fffffc0008083380>] ret_from_fork+0x10/0x50
 [    2.597147] Code: b00057e1 91304021 91005021 b8626822 (b8606821)
 [    2.603464] ---[ end trace 58c0cd36b88802bc ]---
 [    2.608138] Kernel panic - not syncing: Fatal exception

 Fix by moving call to numa_store_cpu_info() for all CPUs into
 smp_prepare_cpus(), which happens before wq_numa_init().  Since
 smp_store_cpu_info() now contains only a single function call,
 simplify by removing the function and out-lining its contents.

Suggested-by: Robert Richter rric@kernel.org
Signed-off-by: David Daney david.daney@cavium.com
Signed-off-by: David Daney david.daney@cavium.com
tested-by: Xinwei Kong kong.kongxinwei@hisilicon.com
Signed-off-by: Xinwei Kong kong.kongxinwei@hisilicon.com
