### PR TITLE
drivers/perf: hisilicon: fix DDRC uncore PMU model issue

### DIFF
--- a/drivers/perf/hisilicon/hisi_uncore_hha_v2.c
+++ b/drivers/perf/hisilicon/hisi_uncore_hha_v2.c
@@ -403,6 +403,7 @@ static struct hisi_uncore_ops_v2 hisi_uncore_HHA_ops = {
 	.start_counters = hisi_hha_start_counters,
 	.stop_counters = hisi_hha_stop_counters,
 	.write_counter = hisi_hha_write_counter,
+	.read_counter = hisi_hha_read_counter,
 };
 
 /* Initialize hrtimer to poll for avoiding counter overflow */

--- a/drivers/perf/hisilicon/hisi_uncore_pmu_v2.c
+++ b/drivers/perf/hisilicon/hisi_uncore_pmu_v2.c
@@ -320,8 +320,7 @@ void hisi_uncore_pmu_start_v2(struct perf_event *event, int flags)
 	if (flags & PERF_EF_RELOAD) {
 		u64 prev_raw_count =  local64_read(&hwc->prev_count);
 
-		hisi_pmu->ops->write_counter(hisi_pmu, hwc,
-					     (u32) prev_raw_count);
+		hisi_pmu->ops->write_counter(hisi_pmu, hwc,(u32)prev_raw_count);
 	}
 
 	/* Start hrtimer when the first event is started in this PMU */


### PR DESCRIPTION
DDRC PMU is different from L3C/HHA PMU, which should be dealed
differently:
1. Event type has been mapped by hardware;
2. Software can't start/stop one counter individual;

Signed-off-by: tiantao <myid2004@126.com>
Signed-off-by: zhangshaokun <zhangshaokun@hisilicon.com>